### PR TITLE
fixed foreign key bug + added auto-updating of new data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,8 @@ Makefile*
 
 /build
 Qt-Secret/
-
+.qtc_clangd/
+.qtc_clangd/.cache/clangd/index
 docs/
 Doxyfile
 

--- a/TicketFlow.pro
+++ b/TicketFlow.pro
@@ -31,6 +31,7 @@ SOURCES += \
     main.cpp \
     mainwindow.cpp \
     manager.cpp \
+    passenger.cpp \
     plane.cpp \
     ticket.cpp
 
@@ -39,6 +40,7 @@ HEADERS += \
     login.h \
     mainwindow.h \
     manager.h \
+    passenger.h \
     plane.h \
     ticket.h
 

--- a/database.cpp
+++ b/database.cpp
@@ -143,8 +143,22 @@ bool Database::addPlaneToDatabase(const Plane& plane){
     return query.exec();
 }
 
-bool Database::deletePlaneFromDatabase(const Plane& plane){
-    if (hasTicketsForPlane(plane)){
+bool Database::deletePlaneFromDatabase(const Plane& plane) {
+    QSqlQuery query;
+
+    query.prepare("SELECT id FROM Planes WHERE model = :model AND airline = :airline AND capacity = :capacity");
+    bindQueryForPlanes(query, plane);
+
+    if (!query.exec() || !query.next()) {
+        qDebug() << "Error finding plane: " << query.lastError().text();
+        return false;
+    }
+
+    int planeId = query.value(0).toInt();
+    Plane planeWithId = plane;
+    planeWithId.setPlaneID(planeId);
+
+    if (hasTicketsForPlane(planeWithId)) {
         QMessageBox::StandardButton reply;
         reply = QMessageBox::warning(nullptr, "Warning",
                                      "This plane has associated tickets. Deleting them will remove all related tickets!",
@@ -153,15 +167,15 @@ bool Database::deletePlaneFromDatabase(const Plane& plane){
         if (reply == QMessageBox::No) {
             return false;
         }
-        if (!deleteTicketsForPlane(plane)) {
+
+        if (!deleteTicketsForPlane(planeWithId)) {
             qDebug() << "Failed to delete tickets for the plane!";
             return false;
         }
     }
 
-    QSqlQuery query;
     query.prepare("DELETE FROM Planes WHERE id = :plane_id");
-    query.bindValue(":plane_id", plane.getPlaneID());
+    query.bindValue(":plane_id", planeWithId.getPlaneID());
 
     return query.exec();
 }
@@ -202,7 +216,24 @@ bool Database::addPassengerToDatabase(const Passenger& passenger){
 }
 
 bool Database::deletePassengerFromDatabase(const Passenger& passenger) {
-    if (hasTicketsForPassenger(passenger)) {
+    QSqlQuery query;
+
+
+    query.prepare("SELECT id FROM Passengers WHERE first_name = :first_name "
+                  "AND last_name = :last_name AND birth_date = :birth_date "
+                  "AND email = :email AND phone_number = :phone_number");
+    bindQueryForPassengers(query, passenger);
+
+    if (!query.exec() || !query.next()) {
+        qDebug() << "Error finding passenger: " << query.lastError().text();
+        return false;
+    }
+
+    int passengerId = query.value(0).toInt();
+    Passenger passengerWithId = passenger;
+    passengerWithId.setPassengerID(passengerId);
+
+    if (hasTicketsForPassenger(passengerWithId)) {
         QMessageBox::StandardButton reply;
         reply = QMessageBox::warning(nullptr, "Warning",
                                      "This passenger has associated tickets. Deleting them will remove all related tickets!",
@@ -211,15 +242,16 @@ bool Database::deletePassengerFromDatabase(const Passenger& passenger) {
         if (reply == QMessageBox::No) {
             return false;
         }
-        if (!deleteTicketsForPassenger(passenger)) {
-            qDebug() << "Failed to delete tickets for passenger:" << passenger.getPassengerID();
+
+        if (!deleteTicketsForPassenger(passengerWithId)) {
+            qDebug() << "Failed to delete tickets for passenger:" << passengerId;
             return false;
         }
     }
 
-    QSqlQuery query;
-    query.prepare("DELETE FROM passengers WHERE id = :id");
-    query.bindValue(":id", passenger.getPassengerID());
+    query.prepare("DELETE FROM Passengers WHERE id = :id");
+    query.bindValue(":id", passengerWithId.getPassengerID());
+
     if (!query.exec()) {
         qDebug() << "Error deleting passenger:" << query.lastError().text();
         return false;
@@ -228,7 +260,7 @@ bool Database::deletePassengerFromDatabase(const Passenger& passenger) {
     return true;
 }
 
-void Database::bindQueryForPassengers(QSqlQuery& query, const Passenger& passenger){
+void Database::bindQueryForPassengers(QSqlQuery& query, const Passenger& passenger) {
     query.bindValue(":first_name", passenger.getfirstName());
     query.bindValue(":last_name", passenger.getLastName());
     query.bindValue(":birth_date", passenger.getBirthDate().toString("yyyy-MM-dd"));

--- a/database.cpp
+++ b/database.cpp
@@ -159,3 +159,60 @@ void Database::bindQueryForPlanes(QSqlQuery& query, const Plane& plane){
     query.bindValue(":airline", plane.getAirline());
     query.bindValue(":capacity", plane.getCapacity());
 }
+
+bool Database::addPassengerToDatabase(const Passenger& passenger){
+    QSqlQuery query;
+    query.prepare("INSERT INTO Passengers (first_name, last_name, birth_date, email, phone_number) "
+                  "VALUES (:first_name, :last_name, :birth_date, :email, :phone_number)");
+
+    bindQueryForPassengers(query, passenger);
+    return query.exec();
+}
+
+bool Database::deletePassengerFromDatabase(const Passenger& passenger) {
+    QSqlQuery query;
+    query.prepare("SELECT COUNT(*) FROM tickets WHERE passenger_id = :passenger_id");
+    query.bindValue(":passenger_id", passenger.getId());
+    if (!query.exec()) {
+        qDebug() << "Error checking tickets: " << query.lastError().text();
+        return false;
+    }
+
+    query.next();
+    int ticketCount = query.value(0).toInt();
+
+    if (ticketCount > 0) {
+        QMessageBox::StandardButton reply;
+        reply = QMessageBox::warning(nullptr, "Warning",
+                                     "This passenger has tickets. Deleting them will remove all their tickets!",
+                                     QMessageBox::Yes | QMessageBox::No);
+
+        if (reply == QMessageBox::No) {
+            return false; // Если пользователь отменяет, не удаляем пассажира
+        }
+
+        // Удаляем все билеты перед удалением пассажира
+        query.prepare("DELETE FROM tickets WHERE passenger_id = :passenger_id");
+        query.bindValue(":passenger_id", passenger.getId());
+        if (!query.exec()) {
+            qDebug() << "Error deleting tickets: " << query.lastError().text();
+            return false;
+        }
+    }
+
+    bindQueryForPassengers(query, passenger);
+    if (!query.exec()) {
+        qDebug() << "Database error on delete:" << query.lastError().text();
+        return false;
+    }
+
+    return true;
+}
+void Database::bindQueryForPassengers(QSqlQuery& query, const Passenger& passenger){
+    query.bindValue(":first_name", passenger.getfirstName());
+    query.bindValue(":last_name", passenger.getLastName());
+    query.bindValue(":birth_date", passenger.getBirthDate().toString("yyyy-MM-dd"));
+    query.bindValue(":email", passenger.getEmail());
+    query.bindValue(":phone_number", passenger.getPhoneNumber());
+}
+

--- a/database.cpp
+++ b/database.cpp
@@ -287,3 +287,10 @@ bool Database::deleteTicketsForPassenger(const Passenger& passenger) {
 
     return query.exec();
 }
+
+void Database::reconnectDatabase() {
+    if (db.isOpen()) {
+        db.close();
+    }
+    db.open();
+}

--- a/database.cpp
+++ b/database.cpp
@@ -144,13 +144,25 @@ bool Database::addPlaneToDatabase(const Plane& plane){
 }
 
 bool Database::deletePlaneFromDatabase(const Plane& plane){
-    QSqlQuery query;
-    query.prepare("DELETE FROM Planes "
-                  "WHERE model = :model "
-                  "AND airline = :airline "
-                  "AND capacity = :capacity");
+    if (hasTicketsForPlane(plane)){
+        QMessageBox::StandardButton reply;
+        reply = QMessageBox::warning(nullptr, "Warning",
+                                     "This plane has associated tickets. Deleting them will remove all related tickets!",
+                                     QMessageBox::Yes | QMessageBox::No);
 
-    bindQueryForPlanes(query, plane);
+        if (reply == QMessageBox::No) {
+            return false;
+        }
+        if (!deleteTicketsForPlane(plane)) {
+            qDebug() << "Failed to delete tickets for the plane!";
+            return false;
+        }
+    }
+
+    QSqlQuery query;
+    query.prepare("DELETE FROM Planes WHERE id = :plane_id");
+    query.bindValue(":plane_id", plane.getPlaneID());
+
     return query.exec();
 }
 
@@ -158,6 +170,26 @@ void Database::bindQueryForPlanes(QSqlQuery& query, const Plane& plane){
     query.bindValue(":model", plane.getModel());
     query.bindValue(":airline", plane.getAirline());
     query.bindValue(":capacity", plane.getCapacity());
+}
+
+bool Database::hasTicketsForPlane(const Plane& plane) {
+    QSqlQuery query;
+    query.prepare("SELECT COUNT(*) FROM Tickets WHERE plane_id = :plane_id");
+    query.bindValue(":plane_id", plane.getPlaneID());
+
+    if (query.exec() && query.next()) {
+        return query.value(0).toInt() > 0;
+    }
+    qDebug() << "Error checking for tickets: " << query.lastError().text();
+    return false;
+}
+
+bool Database::deleteTicketsForPlane(const Plane& plane) {
+    QSqlQuery query;
+    query.prepare("DELETE FROM Tickets WHERE plane_id = :plane_id");
+    query.bindValue(":plane_id", plane.getPlaneID());
+
+    return query.exec();
 }
 
 bool Database::addPassengerToDatabase(const Passenger& passenger){
@@ -170,44 +202,32 @@ bool Database::addPassengerToDatabase(const Passenger& passenger){
 }
 
 bool Database::deletePassengerFromDatabase(const Passenger& passenger) {
-    QSqlQuery query;
-    query.prepare("SELECT COUNT(*) FROM tickets WHERE passenger_id = :passenger_id");
-    query.bindValue(":passenger_id", passenger.getId());
-    if (!query.exec()) {
-        qDebug() << "Error checking tickets: " << query.lastError().text();
-        return false;
-    }
-
-    query.next();
-    int ticketCount = query.value(0).toInt();
-
-    if (ticketCount > 0) {
+    if (hasTicketsForPassenger(passenger)) {
         QMessageBox::StandardButton reply;
         reply = QMessageBox::warning(nullptr, "Warning",
-                                     "This passenger has tickets. Deleting them will remove all their tickets!",
+                                     "This passenger has associated tickets. Deleting them will remove all related tickets!",
                                      QMessageBox::Yes | QMessageBox::No);
 
         if (reply == QMessageBox::No) {
-            return false; // Если пользователь отменяет, не удаляем пассажира
+            return false;
         }
-
-        // Удаляем все билеты перед удалением пассажира
-        query.prepare("DELETE FROM tickets WHERE passenger_id = :passenger_id");
-        query.bindValue(":passenger_id", passenger.getId());
-        if (!query.exec()) {
-            qDebug() << "Error deleting tickets: " << query.lastError().text();
+        if (!deleteTicketsForPassenger(passenger)) {
+            qDebug() << "Failed to delete tickets for passenger:" << passenger.getPassengerID();
             return false;
         }
     }
 
-    bindQueryForPassengers(query, passenger);
+    QSqlQuery query;
+    query.prepare("DELETE FROM passengers WHERE id = :id");
+    query.bindValue(":id", passenger.getPassengerID());
     if (!query.exec()) {
-        qDebug() << "Database error on delete:" << query.lastError().text();
+        qDebug() << "Error deleting passenger:" << query.lastError().text();
         return false;
     }
 
     return true;
 }
+
 void Database::bindQueryForPassengers(QSqlQuery& query, const Passenger& passenger){
     query.bindValue(":first_name", passenger.getfirstName());
     query.bindValue(":last_name", passenger.getLastName());
@@ -216,3 +236,22 @@ void Database::bindQueryForPassengers(QSqlQuery& query, const Passenger& passeng
     query.bindValue(":phone_number", passenger.getPhoneNumber());
 }
 
+bool Database::hasTicketsForPassenger(const Passenger& passenger) {
+    QSqlQuery query;
+    query.prepare("SELECT COUNT(*) FROM Tickets WHERE passenger_id = :passenger_id");
+    query.bindValue(":passenger_id", passenger.getPassengerID());
+
+    if (query.exec() && query.next()) {
+        return query.value(0).toInt() > 0;
+    }
+    qDebug() << "Error checking for tickets: " << query.lastError().text();
+    return false;
+}
+
+bool Database::deleteTicketsForPassenger(const Passenger& passenger) {
+    QSqlQuery query;
+    query.prepare("DELETE FROM Tickets WHERE passenger_id = :passenger_id");
+    query.bindValue(":passenger_id", passenger.getPassengerID());
+
+    return query.exec();
+}

--- a/database.h
+++ b/database.h
@@ -191,6 +191,10 @@ public:
      */
     void bindQueryForPlanes(QSqlQuery& query, const Plane& plane);
 
+    bool hasTicketsForPlane(const Plane& plane);
+
+    bool deleteTicketsForPlane(const Plane& plane);
+
 
     void bindQueryForPassengers(QSqlQuery& query, const Passenger& passenger);
 
@@ -198,6 +202,9 @@ public:
 
     bool deletePassengerFromDatabase(const Passenger& passenger);
 
+    bool deleteTicketsForPassenger(const Passenger& passenger);
+
+    bool hasTicketsForPassenger(const Passenger& passenger);
 
 private:
     /**

--- a/database.h
+++ b/database.h
@@ -269,6 +269,7 @@ public:
      */
     bool hasTicketsForPassenger(const Passenger& passenger);
 
+    void reconnectDatabase();
 private:
     /**
      * @brief Connects to the PostgreSQL database.
@@ -280,7 +281,6 @@ private:
     bool connectToDB();
 
     QSqlDatabase db; ///< Database connection instance.
-
 };
 
 #endif // DATABASE_H

--- a/database.h
+++ b/database.h
@@ -22,10 +22,12 @@
 #include <QSqlDatabase>
 #include <QSqlError>
 #include <QSqlQuery>
+#include <QMessageBox>
 #include <QDebug>
 #include <QComboBox>
 #include "ticket.h"
 #include "plane.h"
+#include "passenger.h"
 
 /**
  * @brief Database schema for airline ticket management.
@@ -189,6 +191,14 @@ public:
      */
     void bindQueryForPlanes(QSqlQuery& query, const Plane& plane);
 
+
+    void bindQueryForPassengers(QSqlQuery& query, const Passenger& passenger);
+
+    bool addPassengerToDatabase(const Passenger& passenger);
+
+    bool deletePassengerFromDatabase(const Passenger& passenger);
+
+
 private:
     /**
      * @brief Connects to the PostgreSQL database.
@@ -200,6 +210,7 @@ private:
     bool connectToDB();
 
     QSqlDatabase db; ///< Database connection instance.
+
 };
 
 #endif // DATABASE_H

--- a/database.h
+++ b/database.h
@@ -191,19 +191,82 @@ public:
      */
     void bindQueryForPlanes(QSqlQuery& query, const Plane& plane);
 
+    /**
+     * @brief Checks if there are any tickets associated with the given plane.
+     *
+     * This method queries the database to determine whether any records exist in the Tickets table
+     * for the specified plane ID. If an error occurs during the query execution, it will be logged.
+     *
+     * @param plane The Plane object for which ticket association is checked.
+     * @return true if there are associated tickets, false otherwise.
+     */
     bool hasTicketsForPlane(const Plane& plane);
 
+    /**
+     * @brief Deletes all tickets associated with the given plane.
+     *
+     * This method removes all entries from the Tickets table that are linked to the specified plane ID.
+     * If the query fails, the error is logged and the method returns false.
+     *
+     * @param plane The Plane object whose associated tickets are to be deleted.
+     * @return true if the deletion was successful, false otherwise.
+     */
     bool deleteTicketsForPlane(const Plane& plane);
 
+    /**
+     * @brief Adds a new passenger to the database.
+     *
+     * This method inserts a new record into the Passengers table using the provided Passenger object's details.
+     * The query parameters are bound using the bindQueryForPassengers helper method.
+     *
+     * @param passenger The Passenger object containing the data to be inserted.
+     * @return true if the insertion is successful, false otherwise.
+     */
+    bool addPassengerToDatabase(const Passenger& passenger);
 
+    /**
+     * @brief Binds passenger details to a SQL query.
+     *
+     * This helper method binds the Passenger object's fields to the corresponding placeholders in the SQL query.
+     * It is typically used before executing queries involving passenger information.
+     *
+     * @param query The QSqlQuery object where the values will be bound.
+     * @param passenger The Passenger object containing the data to bind.
+     */
     void bindQueryForPassengers(QSqlQuery& query, const Passenger& passenger);
 
-    bool addPassengerToDatabase(const Passenger& passenger);
+    /**
+     * @brief Deletes a passenger from the database.
+     *
+     * This method first retrieves the passenger's ID by matching their personal information.
+     * If the passenger has associated tickets, it prompts the user for confirmation and deletes the tickets if agreed.
+     * Finally, it deletes the passenger from the database. If any database operation fails, an error is logged.
+     *
+     * @param passenger The Passenger object representing the passenger to delete.
+     * @return true if the deletion is successful, false otherwise.
+     */
 
     bool deletePassengerFromDatabase(const Passenger& passenger);
 
+    /**
+     * @brief Deletes all tickets associated with a given passenger.
+     *
+     * This method removes all entries from the Tickets table that are linked to the specified passenger.
+     *
+     * @param passenger The Passenger object whose tickets should be deleted.
+     * @return true if the operation was successful, false otherwise.
+     */
     bool deleteTicketsForPassenger(const Passenger& passenger);
 
+    /**
+     * @brief Checks if a passenger has associated tickets.
+     *
+     * This method executes a SQL query to determine whether any tickets are linked to the given passenger
+     * in the Tickets table, based on the passenger's ID.
+     *
+     * @param passenger The Passenger object whose associated tickets are being checked.
+     * @return true if the passenger has at least one associated ticket, false otherwise.
+     */
     bool hasTicketsForPassenger(const Passenger& passenger);
 
 private:

--- a/manager.cpp
+++ b/manager.cpp
@@ -168,62 +168,20 @@ void Manager::on_addPlaneButton_clicked() {
 void Manager::on_deletePlaneButton_clicked() {
     setPlaneOptions();
 
-    if (ifLineFilled(planesLines)) {
-        QSqlQuery query;
-        query.prepare("SELECT COUNT(*) FROM Tickets WHERE plane_id = (SELECT id FROM Planes WHERE model = :model AND airline = :airline "
-                      "AND capacity = :capacity)");
-        query.bindValue(":model", plane.getModel());
-        query.bindValue(":airline", plane.getAirline());
-        query.bindValue(":capacity", plane.getCapacity());
-
-        if (!query.exec()) {
-            ui->statusBarLine->setText("Error checking tickets!");
-            clearStatusBar();
-            return;
-        }
-
-        query.next();
-        int ticketCount = query.value(0).toInt();
-
-        if (ticketCount > 0) {
-            QMessageBox::StandardButton reply;
-            reply = QMessageBox::warning(nullptr, "Warning",
-                                         "This plane has associated tickets. Deleting them will remove all these tickets. Do you want to continue?",
-                                         QMessageBox::Yes | QMessageBox::No);
-
-            if (reply == QMessageBox::No) {
-                return;
-            }
-
-            query.prepare("DELETE FROM Tickets WHERE plane_id = (SELECT id FROM Planes WHERE model = :model AND airline = :airline AND capacity = :capacity)");
-            query.bindValue(":model", plane.getModel());
-            query.bindValue(":airline", plane.getAirline());
-            query.bindValue(":capacity", plane.getCapacity());
-
-            if (!query.exec()) {
-                ui->statusBarLine->setText("Error deleting tickets!");
-                clearStatusBar();
-                return;
-            }
-        }
-
-        query.prepare("DELETE FROM Planes WHERE model = :model AND airline = :airline AND capacity = :capacity");
-        query.bindValue(":model", plane.getModel());
-        query.bindValue(":airline", plane.getAirline());
-        query.bindValue(":capacity", plane.getCapacity());
-
-        if (!query.exec()) {
-            ui->statusBarLine->setText("Failed to delete plane! Database Error.");
-            clearStatusBar();
-            return;
-        }
-
-        ui->statusBarLine->setText("Plane deleted successfully!");
-        clearStatusBar();
-    } else {
+    if (!ifLineFilled(planesLines)) {
         ui->statusBarLine->setText("Failed to delete plane. Fill all lines!");
         clearStatusBar();
+        return;
     }
+
+    if (!db.deletePlaneFromDatabase(plane)) {
+        ui->statusBarLine->setText("Failed to delete plane! Database Error.");
+        clearStatusBar();
+        return;
+    }
+
+    ui->statusBarLine->setText("Plane deleted successfully!");
+    clearStatusBar();
 }
 
 void Manager::setPlaneOptions(){
@@ -252,70 +210,20 @@ void Manager::on_addPassButton_clicked() {
 void Manager::on_deletePassButton_clicked() {
     setPassengerOptions();
 
-    if (ifLineFilled(passengersLines)) {
-        QSqlQuery query;
-        query.prepare("SELECT COUNT(*) FROM Tickets WHERE passenger_id = (SELECT id FROM Passengers WHERE first_name = :first_name"
-                      " AND last_name = :last_name AND birth_date = :birth_date AND email = :email AND phone_number = :phone_number)");
-        query.bindValue(":first_name", passenger.getfirstName());
-        query.bindValue(":last_name", passenger.getLastName());
-        query.bindValue(":birth_date", passenger.getBirthDate());
-        query.bindValue(":email", passenger.getEmail());
-        query.bindValue(":phone_number", passenger.getPhoneNumber());
-
-        if (!query.exec()) {
-            ui->statusBarLine->setText("Error checking tickets!");
-            clearStatusBar();
-            return;
-        }
-
-        query.next();
-        int ticketCount = query.value(0).toInt();
-
-        if (ticketCount > 0) {
-            QMessageBox::StandardButton reply;
-            reply = QMessageBox::warning(nullptr, "Warning",
-                                         "This plane has associated tickets. Deleting them will remove all these tickets. Do you want to continue?",
-                                         QMessageBox::Yes | QMessageBox::No);
-
-            if (reply == QMessageBox::No) {
-                return;
-            }
-
-            query.prepare("DELETE FROM Tickets WHERE passenger_id = (SELECT id FROM Passengers WHERE first_name = :first_name"
-                          " AND last_name = :last_name AND birth_date = :birth_date AND email = :email AND phone_number = :phone_number)");
-            query.bindValue(":first_name", passenger.getfirstName());
-            query.bindValue(":last_name", passenger.getLastName());
-            query.bindValue(":birth_date", passenger.getBirthDate());
-            query.bindValue(":email", passenger.getEmail());
-            query.bindValue(":phone_number", passenger.getPhoneNumber());
-
-            if (!query.exec()) {
-                ui->statusBarLine->setText("Error deleting tickets!");
-                clearStatusBar();
-                return;
-            }
-        }
-
-        query.prepare("DELETE FROM Passengers WHERE first_name = :first_name"
-                      " AND last_name = :last_name AND birth_date = :birth_date AND email = :email AND phone_number = :phone_number");
-        query.bindValue(":first_name", passenger.getfirstName());
-        query.bindValue(":last_name", passenger.getLastName());
-        query.bindValue(":birth_date", passenger.getBirthDate());
-        query.bindValue(":email", passenger.getEmail());
-        query.bindValue(":phone_number", passenger.getPhoneNumber());
-
-        if (!query.exec()) {
-            ui->statusBarLine->setText("Failed to delete passenger! Database Error.");
-            clearStatusBar();
-            return;
-        }
-
-        ui->statusBarLine->setText("Passenger deleted successfully!");
-        clearStatusBar();
-    } else {
+    if (!ifLineFilled(passengersLines)) {
         ui->statusBarLine->setText("Failed to delete passenger. Fill all lines!");
         clearStatusBar();
+        return;
     }
+
+    if (!db.deletePassengerFromDatabase(passenger)) {
+        ui->statusBarLine->setText("Failed to delete passenger! Database Error.");
+        clearStatusBar();
+        return;
+    }
+
+    ui->statusBarLine->setText("Passenger deleted successfully!");
+    clearStatusBar();
 }
 
 void Manager::setPassengerOptions(){

--- a/manager.cpp
+++ b/manager.cpp
@@ -18,7 +18,6 @@
 
 #include "manager.h"
 #include "ui_manager.h"
-#include <QTimer>
 
 Manager::Manager(QWidget *parent)
     : QDialog(parent)
@@ -27,6 +26,11 @@ Manager::Manager(QWidget *parent)
     ui->setupUi(this);
     listWidgetSettings();
     loadInfo();
+
+    QVector<QLineEdit*> ticketsLines = {ui->arrivalCityLine, ui->arrivalTimeLine, ui->departureCityLine, ui->departureTimeLine, ui->priceLine,
+                                  ui->seatNumberLine};
+    QVector<QLineEdit*> planesLines = {ui->modelLine, ui->airlineLine, ui->capacityLine};
+    QVector<QLineEdit*> passengersLines = {ui->firstNameLine, ui->lastNameLine, ui->emailLine, ui->birthDateLine, ui->phoneNumberLine};
 }
 
 Manager::~Manager()
@@ -75,10 +79,8 @@ void Manager::loadInfo(){
 
 void Manager::on_addTicketButton_clicked()
 {
-    QVector<QLineEdit*> lines = {ui->arrivalCityLine, ui->arrivalTimeLine, ui->departureCityLine, ui->departureTimeLine, ui->priceLine,
-                                  ui->seatNumberLine};
     setTicketOptions();
-    if(ifLineFilled(lines)){
+    if(ifLineFilled(ticketsLines)){
         if (db.addTicketToDatabase(ticket)) {
             ui->statusBarLine->setText("Ticket added successfully!");
             clearStatusBar();
@@ -94,10 +96,8 @@ void Manager::on_addTicketButton_clicked()
 
 void Manager::on_deleteTicketButton_clicked()
 {
-    QVector<QLineEdit*> lines = {ui->arrivalCityLine, ui->arrivalTimeLine, ui->departureCityLine, ui->departureTimeLine, ui->priceLine,
-                                  ui->seatNumberLine};
     setTicketOptions();
-    if(ifLineFilled(lines)){
+    if(ifLineFilled(ticketsLines)){
         if(db.deleteTicketFromDatabase(ticket)){
             ui->statusBarLine->setText("Ticket succesfully deleted!");
             clearStatusBar();
@@ -150,10 +150,9 @@ bool Manager::ifLineFilled(QVector<QLineEdit*> lines){
 
 void Manager::on_addPlaneButton_clicked()
 {
-    QVector<QLineEdit*> lines = {ui->modelLine, ui->airlineLine, ui->capacityLine};
     setPlaneOptions();
 
-    if(ifLineFilled(lines)){
+    if(ifLineFilled(planesLines)){
         if(db.addPlaneToDatabase(plane)){
             ui->statusBarLine->setText("Plane added succesfully!");
             clearStatusBar();
@@ -169,10 +168,9 @@ void Manager::on_addPlaneButton_clicked()
 
 void Manager::on_deletePlaneButton_clicked()
 {
-    QVector<QLineEdit*> lines = {ui->modelLine, ui->airlineLine, ui->capacityLine};
     setPlaneOptions();
 
-    if(ifLineFilled(lines)){
+    if(ifLineFilled(planesLines)){
         if(db.deletePlaneFromDatabase(plane)){
             ui->statusBarLine->setText("Plane deleted succesfully!");
             clearStatusBar();
@@ -192,5 +190,51 @@ void Manager::setPlaneOptions(){
     plane.setCapacity(ui->capacityLine->text().toInt());
 }
 
+void Manager::on_addPassButton_clicked()
+{
+    setPassengerOptions();
+
+    if(ifLineFilled(passengersLines)){
+        if(db.addPassengerToDatabase(passenger)){
+            ui->statusBarLine->setText("Passenger added succesfully!");
+            clearStatusBar();
+        } else {
+            ui->statusBarLine->setText("Failed to add passenger! Database Error.");
+            clearStatusBar();
+        }
+    } else {
+        ui->statusBarLine->setText("Failed to add passenger. Fill all lines!");
+        clearStatusBar();
+    }
+}
 
 
+void Manager::on_deletePassButton_clicked()
+{
+    setPassengerOptions();
+
+    if(ifLineFilled(passengersLines)){
+        if(db.deletePassengerFromDatabase(passenger)){
+            ui->statusBarLine->setText("Passenger deleted succesfully!");
+            clearStatusBar();
+        } else {
+            ui->statusBarLine->setText("Failed to delete passenger! Database Error.");
+            clearStatusBar();
+        }
+    } else {
+        ui->statusBarLine->setText("Failed to delete passenger. Fill all lines!");
+        clearStatusBar();
+    }
+}
+
+void Manager::setPassengerOptions(){
+    QString birthDateString = ui->birthDateLine->text();
+    QString format = "yyyy-MM-dd";
+    QDate birthDate = QDate::fromString(birthDateString, format);
+
+    passenger.setFirstName(ui->firstNameLine->text());
+    passenger.setLastName(ui->lastNameLine->text());
+    passenger.setEmail(ui->emailLine->text());
+    passenger.setBirthDate(birthDate);
+    passenger.setPhoneNumber(ui->phoneNumberLine->text());
+}

--- a/manager.cpp
+++ b/manager.cpp
@@ -148,8 +148,7 @@ bool Manager::ifLineFilled(QVector<QLineEdit*> lines){
 }
 
 
-void Manager::on_addPlaneButton_clicked()
-{
+void Manager::on_addPlaneButton_clicked() {
     setPlaneOptions();
 
     if(ifLineFilled(planesLines)){
@@ -166,18 +165,61 @@ void Manager::on_addPlaneButton_clicked()
     }
 }
 
-void Manager::on_deletePlaneButton_clicked()
-{
+void Manager::on_deletePlaneButton_clicked() {
     setPlaneOptions();
 
-    if(ifLineFilled(planesLines)){
-        if(db.deletePlaneFromDatabase(plane)){
-            ui->statusBarLine->setText("Plane deleted succesfully!");
+    if (ifLineFilled(planesLines)) {
+        QSqlQuery query;
+        query.prepare("SELECT COUNT(*) FROM Tickets WHERE plane_id = (SELECT id FROM Planes WHERE model = :model AND airline = :airline "
+                      "AND capacity = :capacity)");
+        query.bindValue(":model", plane.getModel());
+        query.bindValue(":airline", plane.getAirline());
+        query.bindValue(":capacity", plane.getCapacity());
+
+        if (!query.exec()) {
+            ui->statusBarLine->setText("Error checking tickets!");
             clearStatusBar();
-        } else {
+            return;
+        }
+
+        query.next();
+        int ticketCount = query.value(0).toInt();
+
+        if (ticketCount > 0) {
+            QMessageBox::StandardButton reply;
+            reply = QMessageBox::warning(nullptr, "Warning",
+                                         "This plane has associated tickets. Deleting them will remove all these tickets. Do you want to continue?",
+                                         QMessageBox::Yes | QMessageBox::No);
+
+            if (reply == QMessageBox::No) {
+                return;
+            }
+
+            query.prepare("DELETE FROM Tickets WHERE plane_id = (SELECT id FROM Planes WHERE model = :model AND airline = :airline AND capacity = :capacity)");
+            query.bindValue(":model", plane.getModel());
+            query.bindValue(":airline", plane.getAirline());
+            query.bindValue(":capacity", plane.getCapacity());
+
+            if (!query.exec()) {
+                ui->statusBarLine->setText("Error deleting tickets!");
+                clearStatusBar();
+                return;
+            }
+        }
+
+        query.prepare("DELETE FROM Planes WHERE model = :model AND airline = :airline AND capacity = :capacity");
+        query.bindValue(":model", plane.getModel());
+        query.bindValue(":airline", plane.getAirline());
+        query.bindValue(":capacity", plane.getCapacity());
+
+        if (!query.exec()) {
             ui->statusBarLine->setText("Failed to delete plane! Database Error.");
             clearStatusBar();
+            return;
         }
+
+        ui->statusBarLine->setText("Plane deleted successfully!");
+        clearStatusBar();
     } else {
         ui->statusBarLine->setText("Failed to delete plane. Fill all lines!");
         clearStatusBar();
@@ -190,8 +232,7 @@ void Manager::setPlaneOptions(){
     plane.setCapacity(ui->capacityLine->text().toInt());
 }
 
-void Manager::on_addPassButton_clicked()
-{
+void Manager::on_addPassButton_clicked() {
     setPassengerOptions();
 
     if(ifLineFilled(passengersLines)){
@@ -208,19 +249,69 @@ void Manager::on_addPassButton_clicked()
     }
 }
 
-
-void Manager::on_deletePassButton_clicked()
-{
+void Manager::on_deletePassButton_clicked() {
     setPassengerOptions();
 
-    if(ifLineFilled(passengersLines)){
-        if(db.deletePassengerFromDatabase(passenger)){
-            ui->statusBarLine->setText("Passenger deleted succesfully!");
+    if (ifLineFilled(passengersLines)) {
+        QSqlQuery query;
+        query.prepare("SELECT COUNT(*) FROM Tickets WHERE passenger_id = (SELECT id FROM Passengers WHERE first_name = :first_name"
+                      " AND last_name = :last_name AND birth_date = :birth_date AND email = :email AND phone_number = :phone_number)");
+        query.bindValue(":first_name", passenger.getfirstName());
+        query.bindValue(":last_name", passenger.getLastName());
+        query.bindValue(":birth_date", passenger.getBirthDate());
+        query.bindValue(":email", passenger.getEmail());
+        query.bindValue(":phone_number", passenger.getPhoneNumber());
+
+        if (!query.exec()) {
+            ui->statusBarLine->setText("Error checking tickets!");
             clearStatusBar();
-        } else {
+            return;
+        }
+
+        query.next();
+        int ticketCount = query.value(0).toInt();
+
+        if (ticketCount > 0) {
+            QMessageBox::StandardButton reply;
+            reply = QMessageBox::warning(nullptr, "Warning",
+                                         "This plane has associated tickets. Deleting them will remove all these tickets. Do you want to continue?",
+                                         QMessageBox::Yes | QMessageBox::No);
+
+            if (reply == QMessageBox::No) {
+                return;
+            }
+
+            query.prepare("DELETE FROM Tickets WHERE passenger_id = (SELECT id FROM Passengers WHERE first_name = :first_name"
+                          " AND last_name = :last_name AND birth_date = :birth_date AND email = :email AND phone_number = :phone_number)");
+            query.bindValue(":first_name", passenger.getfirstName());
+            query.bindValue(":last_name", passenger.getLastName());
+            query.bindValue(":birth_date", passenger.getBirthDate());
+            query.bindValue(":email", passenger.getEmail());
+            query.bindValue(":phone_number", passenger.getPhoneNumber());
+
+            if (!query.exec()) {
+                ui->statusBarLine->setText("Error deleting tickets!");
+                clearStatusBar();
+                return;
+            }
+        }
+
+        query.prepare("DELETE FROM Passengers WHERE first_name = :first_name"
+                      " AND last_name = :last_name AND birth_date = :birth_date AND email = :email AND phone_number = :phone_number");
+        query.bindValue(":first_name", passenger.getfirstName());
+        query.bindValue(":last_name", passenger.getLastName());
+        query.bindValue(":birth_date", passenger.getBirthDate());
+        query.bindValue(":email", passenger.getEmail());
+        query.bindValue(":phone_number", passenger.getPhoneNumber());
+
+        if (!query.exec()) {
             ui->statusBarLine->setText("Failed to delete passenger! Database Error.");
             clearStatusBar();
+            return;
         }
+
+        ui->statusBarLine->setText("Passenger deleted successfully!");
+        clearStatusBar();
     } else {
         ui->statusBarLine->setText("Failed to delete passenger. Fill all lines!");
         clearStatusBar();
@@ -228,13 +319,9 @@ void Manager::on_deletePassButton_clicked()
 }
 
 void Manager::setPassengerOptions(){
-    QString birthDateString = ui->birthDateLine->text();
-    QString format = "yyyy-MM-dd";
-    QDate birthDate = QDate::fromString(birthDateString, format);
-
     passenger.setFirstName(ui->firstNameLine->text());
     passenger.setLastName(ui->lastNameLine->text());
+    passenger.setBirthDate(QDate::fromString(ui->birthDateLine->text(), "yyyy-MM-dd"));
     passenger.setEmail(ui->emailLine->text());
-    passenger.setBirthDate(birthDate);
     passenger.setPhoneNumber(ui->phoneNumberLine->text());
 }

--- a/manager.cpp
+++ b/manager.cpp
@@ -92,6 +92,7 @@ void Manager::on_addTicketButton_clicked()
         ui->statusBarLine->setText("Failed to add ticket. Fill all lines!");
         clearStatusBar();
     }
+    loadInfo();
 }
 
 void Manager::on_deleteTicketButton_clicked()
@@ -109,6 +110,7 @@ void Manager::on_deleteTicketButton_clicked()
         ui->statusBarLine->setText("Failed to add ticket. Fill all lines!");
         clearStatusBar();
     }
+    loadInfo();
 }
 
 void Manager::setTicketOptions(){
@@ -163,6 +165,7 @@ void Manager::on_addPlaneButton_clicked() {
         ui->statusBarLine->setText("Failed to add plane. Fill all lines!");
         clearStatusBar();
     }
+    loadInfo();
 }
 
 void Manager::on_deletePlaneButton_clicked() {
@@ -182,6 +185,7 @@ void Manager::on_deletePlaneButton_clicked() {
 
     ui->statusBarLine->setText("Plane deleted successfully!");
     clearStatusBar();
+    loadInfo();
 }
 
 void Manager::setPlaneOptions(){
@@ -189,6 +193,7 @@ void Manager::setPlaneOptions(){
     plane.setAirline(ui->airlineLine->text());
     plane.setCapacity(ui->capacityLine->text().toInt());
 }
+
 
 void Manager::on_addPassButton_clicked() {
     setPassengerOptions();
@@ -205,6 +210,7 @@ void Manager::on_addPassButton_clicked() {
         ui->statusBarLine->setText("Failed to add passenger. Fill all lines!");
         clearStatusBar();
     }
+    loadInfo();
 }
 
 void Manager::on_deletePassButton_clicked() {
@@ -224,6 +230,7 @@ void Manager::on_deletePassButton_clicked() {
 
     ui->statusBarLine->setText("Passenger deleted successfully!");
     clearStatusBar();
+    loadInfo();
 }
 
 void Manager::setPassengerOptions(){

--- a/manager.h
+++ b/manager.h
@@ -23,10 +23,12 @@
 #include "database.h"
 #include "ticket.h"
 #include "plane.h"
+#include "passenger.h"
 #include <QString>
 #include <QDialog>
 #include <QVector>
 #include <QDebug>
+#include <QTimer>
 
 namespace Ui {
 class Manager;
@@ -106,13 +108,22 @@ private slots:
      */
     void on_deletePlaneButton_clicked();
 
+    void on_deletePassButton_clicked();
+
+    void on_addPassButton_clicked();
+
 private:
     Ui::Manager *ui; ///< Pointer to the user interface of the manager window.
     Database db; ///< Manages interactions with the database.
     Ticket ticket; ///< Holds ticket details.
     Plane plane; ///< Holds plane details.
+    Passenger passenger; ///< Holds passenger details.
     QVector<Ticket> tickets; ///< List of tickets.
 
+
+    QVector<QLineEdit*> ticketsLines;
+    QVector<QLineEdit*> planesLines;
+    QVector<QLineEdit*> passengersLines;
     /**
      * @brief Configures the list widget for the manager window.
      * Adds navigation items to switch between different management pages (tickets, passengers, planes).
@@ -143,6 +154,8 @@ private:
      * `plane` object. This data will later be used for adding or deleting the plane from the database.
      */
     void setPlaneOptions();
+
+    void setPassengerOptions();
 
     /**
      * @brief Clears the status bar message after a delay.

--- a/manager.h
+++ b/manager.h
@@ -44,12 +44,21 @@ class Manager;
  *
  * Private Slots:
  * - `on_addTicketButton_clicked()`: Handles the addition of a new ticket to the database.
+ * - `on_deleteTicketButton_clicked()`: Handles ticket deletion from the database.
+ * - `on_addPlaneButton_clicked()`: Adds a new plane to the database.
+ * - `on_deletePlaneButton_clicked()`: Deletes a plane from the database.
+ * - `on_deletePassButton_clicked()`: Handles the deletion of a passenger from the database.
+ * - `on_addPassButton_clicked()`: Handles the addition of a new passenger to the database.
  *
  * Private Methods:
  * - `listWidgetSettings()`: Configures the list widget for navigation between different management pages.
  * - `changePage(int index)`: Changes the page based on the user's selection in the list widget.
  * - `loadInfo()`: Loads data from the database into combo boxes for passengers and planes.
  * - `setTicketOptions()`: Sets the ticket details (e.g., passenger, plane, departure time) for a new ticket.
+ * - `setPlaneOptions()`: Sets the plane options (e.g., model, airline, seating capacity).
+ * - `setPassengerOptions()`: Sets the passenger options (e.g., first name, last name, birth date, email, phone).
+ * - `clearStatusBar()`: Clears the status bar message after a delay.
+ * - `ifLineFilled(QVector<QLineEdit*> lines)`: Checks if all required input fields are filled.
  */
 class Manager : public QDialog
 {
@@ -108,8 +117,21 @@ private slots:
      */
     void on_deletePlaneButton_clicked();
 
+    /**
+     * @brief Slot triggered when the "Delete Passenger" button is clicked.
+     *
+     * This method collects input from the passenger fields, checks if all required fields are filled,
+     * verifies if the passenger has associated tickets, prompts for confirmation if needed,
+     * and attempts to delete the passenger from the database. Updates the status bar accordingly.
+     */
     void on_deletePassButton_clicked();
 
+    /**
+     * @brief Slot triggered when the "Add Passenger" button is clicked.
+     *
+     * This method collects input from the passenger fields, checks if all required fields are filled,
+     * and attempts to add a new passenger to the database. Updates the status bar based on the operation result.
+     */
     void on_addPassButton_clicked();
 
 private:
@@ -118,12 +140,32 @@ private:
     Ticket ticket; ///< Holds ticket details.
     Plane plane; ///< Holds plane details.
     Passenger passenger; ///< Holds passenger details.
-    QVector<Ticket> tickets; ///< List of tickets.
+    QVector<Ticket> tickets; ///< List of tickets. 
 
-
+    /**
+     * @brief A QVector containing the line edit fields for ticket information.
+     *
+     * This QVector holds pointers to QLineEdit widgets used to input ticket data, including arrival city,
+     * arrival time, departure city, departure time, price, and seat number.
+     */
     QVector<QLineEdit*> ticketsLines;
+
+    /**
+     * @brief A QVector containing the line edit fields for plane information.
+     *
+     * This QVector holds pointers to QLineEdit widgets used to input plane data, including the model,
+     * airline, and seating capacity.
+     */
     QVector<QLineEdit*> planesLines;
+
+    /**
+     * @brief A QVector containing the line edit fields for passenger information.
+     *
+     * This QVector holds pointers to QLineEdit widgets used to input passenger data, including the first name,
+     * last name, email, birth date, and phone number.
+     */
     QVector<QLineEdit*> passengersLines;
+
     /**
      * @brief Configures the list widget for the manager window.
      * Adds navigation items to switch between different management pages (tickets, passengers, planes).
@@ -155,6 +197,13 @@ private:
      */
     void setPlaneOptions();
 
+    /**
+     * @brief Sets the options for the passenger object based on the input from the GUI.
+     *
+     * This function retrieves the text input from the user in the QLineEdit fields related to the passenger's
+     * first name, last name, birth date, email, and phone number, and sets the corresponding properties in
+     * the `passenger` object. The birth date is parsed from the text using the format "yyyy-MM-dd".
+     */
     void setPassengerOptions();
 
     /**

--- a/manager.ui
+++ b/manager.ui
@@ -60,9 +60,9 @@ QListWidget::item:selected {
   <widget class="QStackedWidget" name="stackedWidget">
    <property name="geometry">
     <rect>
-     <x>330</x>
+     <x>320</x>
      <y>20</y>
-     <width>651</width>
+     <width>661</width>
      <height>651</height>
     </rect>
    </property>
@@ -763,7 +763,7 @@ QPushButton:pressed {
     <widget class="QWidget" name="verticalLayoutWidget_4">
      <property name="geometry">
       <rect>
-       <x>0</x>
+       <x>10</x>
        <y>130</y>
        <width>160</width>
        <height>241</height>
@@ -771,7 +771,10 @@ QPushButton:pressed {
      </property>
      <layout class="QVBoxLayout" name="planeLabelLayout">
       <property name="leftMargin">
-       <number>30</number>
+       <number>10</number>
+      </property>
+      <property name="topMargin">
+       <number>5</number>
       </property>
       <item>
        <widget class="QLabel" name="modelLabel">
@@ -780,6 +783,13 @@ QPushButton:pressed {
           <family>Monospace</family>
           <pointsize>-1</pointsize>
          </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QLabel {
+    color: #1c1c1c; 
+    background: transparent; 
+    font-size: 22px;
+}</string>
         </property>
         <property name="text">
          <string>Model</string>
@@ -794,6 +804,13 @@ QPushButton:pressed {
           <pointsize>-1</pointsize>
          </font>
         </property>
+        <property name="styleSheet">
+         <string notr="true">QLabel {
+    color: #1c1c1c; 
+    background: transparent; 
+    font-size: 22px;
+}</string>
+        </property>
         <property name="text">
          <string>Airline</string>
         </property>
@@ -806,6 +823,13 @@ QPushButton:pressed {
           <family>Monospace</family>
           <pointsize>-1</pointsize>
          </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QLabel {
+    color: #1c1c1c; 
+    background: transparent; 
+    font-size: 22px;
+}</string>
         </property>
         <property name="text">
          <string>Capacity</string>
@@ -820,7 +844,7 @@ QPushButton:pressed {
        <x>160</x>
        <y>110</y>
        <width>471</width>
-       <height>301</height>
+       <height>291</height>
       </rect>
      </property>
      <layout class="QVBoxLayout" name="linesLayout">
@@ -1023,6 +1047,333 @@ QPushButton:pressed {
      <property name="text">
       <string>PASSENGERS MANAGER</string>
      </property>
+    </widget>
+    <widget class="QWidget" name="horizontalLayoutWidget_2">
+     <property name="geometry">
+      <rect>
+       <x>90</x>
+       <y>520</y>
+       <width>491</width>
+       <height>91</height>
+      </rect>
+     </property>
+     <layout class="QHBoxLayout" name="passengersButtonsLayout">
+      <property name="spacing">
+       <number>20</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="addPassButton">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <pointsize>17</pointsize>
+         </font>
+        </property>
+        <property name="cursor">
+         <cursorShape>PointingHandCursor</cursorShape>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QPushButton {
+    background-color: #4682b4; 
+    color: white;
+    border: none;
+    border-radius: 10px;
+    padding: 8px 16px;
+}
+
+QPushButton:hover {
+    background-color: #5a9bd5; 
+}
+
+QPushButton:pressed {
+    background-color: #2e5984; 
+}
+</string>
+        </property>
+        <property name="text">
+         <string>ADD PASSENGER</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="deletePassButton">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <pointsize>17</pointsize>
+         </font>
+        </property>
+        <property name="cursor">
+         <cursorShape>PointingHandCursor</cursorShape>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QPushButton {
+    background-color: #dc143c; 
+    color: white;
+    border: none;
+    border-radius: 10px;
+    padding: 8px 16px;
+}
+
+QPushButton:hover {
+    background-color: #e94b6d;
+}
+
+QPushButton:pressed {
+    background-color: #a60f2d;
+}
+</string>
+        </property>
+        <property name="text">
+         <string>DELETE PASSENGER</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+    <widget class="QWidget" name="verticalLayoutWidget_6">
+     <property name="geometry">
+      <rect>
+       <x>180</x>
+       <y>120</y>
+       <width>481</width>
+       <height>371</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="addPassLinesLayout">
+      <item>
+       <widget class="QLineEdit" name="firstNameLine">
+        <property name="styleSheet">
+         <string notr="true">QLineEdit {
+    border: 2px solid #3498db;  
+    border-radius: 5px;  
+    padding: 5px;
+    background-color: #ecf0f1; 
+    color: #2c3e50; 
+    font-size: 14px;
+    font-family: Arial, sans-serif;
+}
+
+QLineEdit:hover {
+    border-color: #2980b9;  
+}
+
+QLineEdit:focus {
+    border-color: #2980b9;  
+    background-color: #ffffff;  
+}</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="lastNameLine">
+        <property name="styleSheet">
+         <string notr="true">QLineEdit {
+    border: 2px solid #3498db;  
+    border-radius: 5px;  
+    padding: 5px;
+    background-color: #ecf0f1; 
+    color: #2c3e50; 
+    font-size: 14px;
+    font-family: Arial, sans-serif;
+}
+
+QLineEdit:hover {
+    border-color: #2980b9;  
+}
+
+QLineEdit:focus {
+    border-color: #2980b9;  
+    background-color: #ffffff;  
+}</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="birthDateLine">
+        <property name="styleSheet">
+         <string notr="true">QLineEdit {
+    border: 2px solid #3498db;  
+    border-radius: 5px;  
+    padding: 5px;
+    background-color: #ecf0f1; 
+    color: #2c3e50; 
+    font-size: 14px;
+    font-family: Arial, sans-serif;
+}
+
+QLineEdit:hover {
+    border-color: #2980b9;  
+}
+
+QLineEdit:focus {
+    border-color: #2980b9;  
+    background-color: #ffffff;  
+}</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="emailLine">
+        <property name="styleSheet">
+         <string notr="true">QLineEdit {
+    border: 2px solid #3498db;  
+    border-radius: 5px;  
+    padding: 5px;
+    background-color: #ecf0f1; 
+    color: #2c3e50; 
+    font-size: 14px;
+    font-family: Arial, sans-serif;
+}
+
+QLineEdit:hover {
+    border-color: #2980b9;  
+}
+
+QLineEdit:focus {
+    border-color: #2980b9;  
+    background-color: #ffffff;  
+}</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="phoneNumberLine">
+        <property name="styleSheet">
+         <string notr="true">QLineEdit {
+    border: 2px solid #3498db;  
+    border-radius: 5px;  
+    padding: 5px;
+    background-color: #ecf0f1; 
+    color: #2c3e50; 
+    font-size: 14px;
+    font-family: Arial, sans-serif;
+}
+
+QLineEdit:hover {
+    border-color: #2980b9;  
+}
+
+QLineEdit:focus {
+    border-color: #2980b9;  
+    background-color: #ffffff;  
+}</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+    <widget class="QWidget" name="verticalLayoutWidget_7">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>130</y>
+       <width>171</width>
+       <height>341</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="addPassLabelLayout">
+      <item>
+       <widget class="QLabel" name="firstNameLabel">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <pointsize>-1</pointsize>
+         </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QLabel {
+    color: #1c1c1c; 
+    background: transparent; 
+    font-size: 22px;
+}</string>
+        </property>
+        <property name="text">
+         <string>First Name</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="lastNameLabel">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <pointsize>-1</pointsize>
+         </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QLabel {
+    color: #1c1c1c; 
+    background: transparent; 
+    font-size: 22px;
+}</string>
+        </property>
+        <property name="text">
+         <string>Last Name</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="birthDateLabel">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <pointsize>-1</pointsize>
+         </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QLabel {
+    color: #1c1c1c; 
+    background: transparent; 
+    font-size: 22px;
+}</string>
+        </property>
+        <property name="text">
+         <string>Birth Date</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="emailLabel">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <pointsize>-1</pointsize>
+         </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QLabel {
+    color: #1c1c1c; 
+    background: transparent; 
+    font-size: 22px;
+}</string>
+        </property>
+        <property name="text">
+         <string>Email</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="phoneNumberLabel">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+          <pointsize>-1</pointsize>
+         </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QLabel {
+    color: #1c1c1c; 
+    background: transparent; 
+    font-size: 22px;
+}</string>
+        </property>
+        <property name="text">
+         <string>Phone Number</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </widget>
   </widget>

--- a/passenger.cpp
+++ b/passenger.cpp
@@ -22,6 +22,10 @@ QDate Passenger::getBirthDate() const{
     return birthDate;
 }
 
+int Passenger::getPassengerID() const{
+    return ID;
+}
+
 void Passenger::setFirstName(QString firstName){
     this->firstName = firstName;
 }
@@ -41,3 +45,5 @@ void Passenger::setPhoneNumber(QString phoneNumber){
 void Passenger::setBirthDate(QDate birthDate){
     this->birthDate = birthDate;
 }
+
+

--- a/passenger.cpp
+++ b/passenger.cpp
@@ -1,3 +1,22 @@
+/*
+ * TicketFlow
+ * Copyright (C) 2025 minnesang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
 #include "passenger.h"
 
 Passenger::Passenger() {}
@@ -46,4 +65,7 @@ void Passenger::setBirthDate(QDate birthDate){
     this->birthDate = birthDate;
 }
 
+void Passenger::setPassengerID(int ID){
+    this->ID = ID;
+}
 

--- a/passenger.cpp
+++ b/passenger.cpp
@@ -1,0 +1,43 @@
+#include "passenger.h"
+
+Passenger::Passenger() {}
+
+QString Passenger::getfirstName() const{
+    return firstName;
+}
+
+QString Passenger::getLastName() const{
+    return lastName;
+}
+
+QString Passenger::getEmail() const{
+    return email;
+}
+
+QString Passenger::getPhoneNumber() const{
+    return phoneNumber;
+}
+
+QDate Passenger::getBirthDate() const{
+    return birthDate;
+}
+
+void Passenger::setFirstName(QString firstName){
+    this->firstName = firstName;
+}
+
+void Passenger::setLastName(QString lastName){
+    this->lastName = lastName;
+}
+
+void Passenger::setEmail(QString email){
+    this->email = email;
+}
+
+void Passenger::setPhoneNumber(QString phoneNumber){
+    this->phoneNumber = phoneNumber;
+}
+
+void Passenger::setBirthDate(QDate birthDate){
+    this->birthDate = birthDate;
+}

--- a/passenger.h
+++ b/passenger.h
@@ -1,31 +1,145 @@
+/*
+ * TicketFlow
+ * Copyright (C) 2025 minnesang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
 #ifndef PASSENGER_H
 #define PASSENGER_H
 
 #include <QString>
 #include <QDate>
 
+/**
+ * @brief This file defines the Passenger class, which represents a passenger in the flight ticketing system.
+ *
+ * The Passenger class provides attributes and methods for storing and managing a passenger's personal details,
+ * including name, email, phone number, birth date, and a unique passenger ID.
+ *
+ * Public Methods:
+ * - `Passenger()`: Default constructor for initializing a passenger object.
+ * - `getFirstName()`: Returns the first name of the passenger.
+ * - `getLastName()`: Returns the last name of the passenger.
+ * - `getEmail()`: Returns the email of the passenger.
+ * - `getPhoneNumber()`: Returns the phone number of the passenger.
+ * - `getBirthDate()`: Returns the birth date of the passenger.
+ * - `getPassengerID()`: Returns the unique ID of the passenger.
+ * - `setFirstName(QString firstName)`: Sets the first name of the passenger.
+ * - `setLastName(QString lastName)`: Sets the last name of the passenger.
+ * - `setEmail(QString email)`: Sets the email of the passenger.
+ * - `setPhoneNumber(QString phoneNumber)`: Sets the phone number of the passenger.
+ * - `setBirthDate(QDate birthDate)`: Sets the birth date of the passenger.
+ * - `setPassengerID(int ID)`: Sets the unique ID of the passenger.
+ *
+ * Attributes:
+ * - `firstName`: The first name of the passenger.
+ * - `lastName`: The last name of the passenger.
+ * - `email`: The email address of the passenger.
+ * - `phoneNumber`: The phone number of the passenger.
+ * - `birthDate`: The birth date of the passenger.
+ * - `ID`: The unique ID assigned to the passenger.
+ */
 class Passenger
 {
 public:
+    /**
+     * @brief Default constructor for the Passenger class.
+     * Initializes a passenger object with default values.
+     */
     Passenger();
 
+    /**
+     * @brief Gets the first name of the passenger.
+     * @return The first name of the passenger.
+     */
     QString getfirstName() const;
+
+    /**
+     * @brief Gets the last name of the passenger.
+     * @return The last name of the passenger.
+     */
     QString getLastName() const;
+
+    /**
+     * @brief Gets the email of the passenger.
+     * @return The email of the passenger.
+     */
     QString getEmail() const;
+
+    /**
+     * @brief Gets the phone number of the passenger.
+     * @return The phone number of the passenger.
+     */
     QString getPhoneNumber() const;
+
+    /**
+     * @brief Gets the birth date of the passenger.
+     * @return The birth date of the passenger.
+     */
     QDate getBirthDate() const;
+
+    /**
+     * @brief Gets the unique ID of the passenger.
+     * @return The unique ID of the passenger.
+     */
     int getPassengerID() const;
 
+    /**
+     * @brief Sets the first name of the passenger.
+     * @param firstName The first name of the passenger.
+     */
     void setFirstName(QString firstName);
+
+    /**
+     * @brief Sets the last name of the passenger.
+     * @param lastName The last name of the passenger.
+     */
     void setLastName(QString lastName);
+
+    /**
+     * @brief Sets the email of the passenger.
+     * @param email The email address of the passenger.
+     */
     void setEmail(QString email);
+
+    /**
+     * @brief Sets the phone number of the passenger.
+     * @param phoneNumber The phone number of the passenger.
+     */
     void setPhoneNumber(QString phoneNumber);
+
+    /**
+     * @brief Sets the birth date of the passenger.
+     * @param birthDate The birth date of the passenger.
+     */
     void setBirthDate(QDate birthDate);
 
+    /**
+     * @brief Sets the unique ID of the passenger.
+     * @param ID The unique ID of the passenger.
+     */
+    void setPassengerID(int ID);
+
 private:
-    QString firstName, lastName, email, phoneNumber;
-    QDate birthDate;
-    int ID;
+    QString firstName; ///< The first name of the passenger.
+    QString lastName; ///< The last name of the passenger.
+    QString email; ///< The email address of the passenger.
+    QString phoneNumber; ///< The phone number of the passenger.
+    QDate birthDate; ///< The birth date of the passenger.
+    int ID; ///< The unique ID assigned to the passenger.
 };
 
 #endif // PASSENGER_H

--- a/passenger.h
+++ b/passenger.h
@@ -14,6 +14,7 @@ public:
     QString getEmail() const;
     QString getPhoneNumber() const;
     QDate getBirthDate() const;
+    int getPassengerID() const;
 
     void setFirstName(QString firstName);
     void setLastName(QString lastName);
@@ -24,6 +25,7 @@ public:
 private:
     QString firstName, lastName, email, phoneNumber;
     QDate birthDate;
+    int ID;
 };
 
 #endif // PASSENGER_H

--- a/passenger.h
+++ b/passenger.h
@@ -1,0 +1,29 @@
+#ifndef PASSENGER_H
+#define PASSENGER_H
+
+#include <QString>
+#include <QDate>
+
+class Passenger
+{
+public:
+    Passenger();
+
+    QString getfirstName() const;
+    QString getLastName() const;
+    QString getEmail() const;
+    QString getPhoneNumber() const;
+    QDate getBirthDate() const;
+
+    void setFirstName(QString firstName);
+    void setLastName(QString lastName);
+    void setEmail(QString email);
+    void setPhoneNumber(QString phoneNumber);
+    void setBirthDate(QDate birthDate);
+
+private:
+    QString firstName, lastName, email, phoneNumber;
+    QDate birthDate;
+};
+
+#endif // PASSENGER_H

--- a/plane.cpp
+++ b/plane.cpp
@@ -32,6 +32,10 @@ void Plane::setCapacity(int capacity){
     this->capacity = capacity;
 }
 
+void Plane::setPlaneID(int ID){
+    this->ID = ID;
+}
+
 QString Plane::getModel() const{
     return model;
 }

--- a/plane.cpp
+++ b/plane.cpp
@@ -43,3 +43,7 @@ QString Plane::getAirline() const{
 int Plane::getCapacity() const{
     return capacity;
 }
+
+int Plane::getPlaneID() const{
+    return ID;
+}

--- a/plane.h
+++ b/plane.h
@@ -95,10 +95,12 @@ public:
      */
     int getCapacity() const;
 
+    int getPlaneID() const;
+
 private:
     QString model;    /**< Model of the plane (e.g., "Boeing 737") */
     QString airline;  /**< Airline of the plane (e.g., "American Airlines") */
-    int capacity;     /**< Maximum number of passengers the plane can carry */
+    int capacity, ID;     /**< Maximum number of passengers the plane can carry */
 };
 
 #endif // PLANE_H

--- a/plane.h
+++ b/plane.h
@@ -34,14 +34,17 @@
  * - `setModel(QString model)`: Sets the model of the airplane (e.g., "Boeing 737").
  * - `setAirline(QString airline)`: Sets the airline operating the airplane (e.g., "American Airlines").
  * - `setCapacity(int capacity)`: Sets the seating capacity of the airplane.
+ * - `setPlaneID(int ID)`: Sets the unique ID of the plane.
  * - `getModel()`: Gets the model of the airplane.
  * - `getAirline()`: Gets the airline operating the airplane.
  * - `getCapacity()`: Gets the seating capacity of the airplane.
+ * - `getPlaneID()`: Gets the unique ID of the airplane.
  *
  * Attributes:
  * - `model`: The model of the airplane (e.g., "Boeing 737").
  * - `airline`: The airline operating the airplane (e.g., "American Airlines").
  * - `capacity`: The seating capacity of the airplane, representing the maximum number of passengers it can carry.
+ * - `ID`: The unique identifier for the plane.
  */
 class Plane
 {
@@ -75,6 +78,16 @@ public:
     void setCapacity(int capacity);
 
     /**
+     * @brief Sets the unique ID of the plane.
+     *
+     * This method sets the unique identifier (ID) for the plane object. The ID is used to identify
+     * the plane in the database or within the program.
+     *
+     * @param ID The unique ID to assign to the plane.
+     */
+    void setPlaneID(int ID);
+
+    /**
      * @brief Retrieves the model of the plane.
      *
      * @return The model of the plane (e.g., "Boeing 737").
@@ -95,6 +108,14 @@ public:
      */
     int getCapacity() const;
 
+    /**
+     * @brief Gets the unique ID of the plane.
+     *
+     * This method returns the unique identifier (ID) of the plane object. The ID is used to identify
+     * the plane in the database or within the program.
+     *
+     * @return int The unique ID of the plane.
+     */
     int getPlaneID() const;
 
 private:

--- a/ticket.h
+++ b/ticket.h
@@ -34,8 +34,8 @@
  * - `Ticket()`: Constructor for initializing a ticket.
  * - `setPassengerID(int passengerID)`: Sets the ID of the passenger associated with the ticket.
  * - `setPlaneID(int planeID)`: Sets the ID of the plane associated with the ticket.
- * - `setPrice(int price)`: Sets the price of the ticket.
- * - `setSeatNumber(int seatNumber)`: Sets the seat number for the ticket.
+ * - `setPrice(float price)`: Sets the price of the ticket.
+ * - `setSeatNumber(QString seatNumber)`: Sets the seat number for the ticket.
  * - `setDepartureCity(QString departureCity)`: Sets the departure city for the flight.
  * - `setArrivalCity(QString arrivalCity)`: Sets the arrival city for the flight.
  * - `setDepartureTime(QDateTime departureTime)`: Sets the departure time for the flight.
@@ -60,7 +60,6 @@
  * - `passengerID`: The ID of the passenger who owns the ticket.
  * - `planeID`: The ID of the plane for the flight.
  */
-
 class Ticket
 {
 public:


### PR DESCRIPTION
I fixed a bug where passengers and planes that were associated with tickets couldn't be deleted due to foreign keys in the 'Tickets' table. Now, if there are tickets associated with a passenger or a plane, a warning appears first, notifying that all related tickets will be deleted. All tickets are removed, and then the passenger or plane is deleted. I also implemented automatic updating of the combo boxes (with new planes and passengers).